### PR TITLE
Allow URI to be set on init

### DIFF
--- a/models/DeeplClient.cfc
+++ b/models/DeeplClient.cfc
@@ -25,8 +25,12 @@ component hint="" accessors="true" Singleton{
 	 */
 	public DeeplClient function init(
 		string apiKey
+		,string uri
 	) {
 		variables.apikey=apiKey;
+		if (StructKeyExists(Arguments, 'uri')) {
+			variables.uri=arguments.uri;
+		}		
 		
 		//set once supported languges
 		variables.aSupportedLanguages=getLanguages();


### PR DESCRIPTION
My DeepL key requires V2 of the API, though the existing calls seem to work with it.
Note that V2 has a separate URI for free vs paid plans.
Added a param allow for provision of a URI on init. We're unable to do this after init due to the call to `getLanguages()`.